### PR TITLE
dependency change rust-crypto → hmac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csrf-token"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Yusuke Yoshimoto <y.yoshimoto@f-s-r.jp>"]
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ publish = false
 [dependencies]
 chrono = "0.4.6"
 rand = "0.5.5"
-rust-crypto = "0.2.36"
 byteorder = "1.2.6"
 failure = "0.1.3"
+hmac = "0.7.0"
+sha2 = "0.8.0"
 
 [dev-dependencies]
 base64 = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generation and verification of CSRF prevention tokens.
 Add the following dependency to `Cargo.toml`.
 
 ```
-csrf-token = { git = "ssh://git@github.com/future-science-research/csrf-token.git" }
+csrf-token = { git = "ssh://git@github.com/future-science-research/csrf-token.git", branch="v0.2.x" }
 ```
 
 ## Running Example

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,6 @@
 extern crate actix_web;
 extern crate base64;
 extern crate chrono;
-extern crate crypto;
 extern crate csrf_token;
 #[macro_use]
 extern crate failure;

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -18,16 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+use crate::HmacSha256;
+use hmac::Mac;
 
-pub(crate) fn compute_digest(
-    digest: &mut Hmac<Sha256>,
-    nonce: &[u8],
-    expiry: &[u8],
-    secret: &[u8],
-) -> Vec<u8> {
-    let mut digest = digest.clone(); // FIXME: noclone
+pub(crate) fn compute_digest(nonce: &[u8], expiry: &[u8], secret: &[u8]) -> Vec<u8> {
+    let mut digest = HmacSha256::new_varkey(secret).expect("create HMACSHA256 from varkey");
     digest.input(nonce);
     digest.input(expiry);
     digest.input(secret);

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -18,18 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crypto::{digest::Digest, sha2::Sha256};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 pub(crate) fn compute_digest(
-    digest: &mut Sha256,
+    digest: &mut Hmac<Sha256>,
     nonce: &[u8],
     expiry: &[u8],
     secret: &[u8],
 ) -> Vec<u8> {
+    let mut digest = digest.clone(); // FIXME: noclone
     digest.input(nonce);
     digest.input(expiry);
     digest.input(secret);
-    let mut result = vec![0; digest.output_bytes()];
-    digest.result(&mut result);
-    result
+    let result = digest.result();
+    result.code().into_iter().collect()
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -19,24 +19,25 @@
 // SOFTWARE.
 
 use chrono::prelude::*;
-use crypto::{digest::Digest, sha2::Sha256};
+use crate::HMACSHA256_BYTES;
 use digest::compute_digest;
 use expiry::{expiry_to_bytes, EXPIRY_SIZE};
+use hmac::Hmac;
 use rand::{thread_rng, Rng};
+use sha2::Sha256;
 use std::io::{self, Write};
 
 pub(super) fn generate_token(
     secret: &[u8],
     expiry: DateTime<Utc>,
     nonce_size: usize,
-    digest: &mut Sha256,
+    digest: &mut Hmac<Sha256>,
 ) -> Vec<u8> {
     let mut nonce = vec![0; nonce_size];
     thread_rng().fill(nonce.as_mut_slice());
     let expiry = expiry_to_bytes(expiry);
     let digest_value = compute_digest(digest, &nonce, &expiry, secret);
-
-    let mut result = Vec::with_capacity(nonce_size + EXPIRY_SIZE + digest.output_bytes());
+    let mut result = Vec::with_capacity(nonce_size + EXPIRY_SIZE + HMACSHA256_BYTES);
     result.write(&nonce).unwrap();
     result.write(&expiry).unwrap_or_else(|error| {
         if error.kind() == io::ErrorKind::InvalidData {
@@ -52,18 +53,26 @@ pub(super) fn generate_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::HmacSha256;
+    use hmac::Mac;
+
+    fn secret() -> Vec<u8> {
+        b"0123456789abcedf0123456789abcdef".to_vec()
+    }
 
     #[test]
     #[should_panic]
     fn test_generate_token_with_far_past_expiry() {
+        let mut digest = HmacSha256::new_varkey(&secret()).expect("expect HMACSHA256 from varkey");
         let expiry = DateTime::from_utc(NaiveDateTime::from_timestamp(i64::min_value(), 0), Utc);
-        generate_token(&[], expiry, 32, &mut Sha256::new());
+        generate_token(&[], expiry, 32, &mut digest);
     }
 
     #[test]
     #[should_panic]
     fn test_generate_token_with_far_future_expiry() {
+        let mut digest = HmacSha256::new_varkey(&secret()).expect("expect HMACSHA256 from varkey");
         let expiry = DateTime::from_utc(NaiveDateTime::from_timestamp(i64::max_value(), 0), Utc);
-        generate_token(&[], expiry, 32, &mut Sha256::new());
+        generate_token(&[], expiry, 32, &mut digest);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! - nonce
 //! - expiry date and time
-//! - hash digest of secret, nonce and expiry
+//! - HMAC for nonce and expiry
 //!
 //! These values are not private. The client can get to know these values
 //! by investigating the given token.
@@ -40,16 +40,16 @@ extern crate sha2;
 extern crate failure;
 extern crate rand;
 
-mod digest;
 mod expiry;
 mod generate;
+mod signature;
 mod verify;
 
 use chrono::{prelude::*, Duration};
-use generate::generate_token;
+use crate::{generate::generate_token, verify::verify_token};
 use hmac::Hmac;
 use sha2::Sha256;
-use verify::verify_token;
+
 type HmacSha256 = Hmac<Sha256>;
 const HMACSHA256_BITS: usize = 256;
 const HMACSHA256_BYTES: usize = HMACSHA256_BITS / 8;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -21,11 +21,10 @@
 use crate::HmacSha256;
 use hmac::Mac;
 
-pub(crate) fn compute_digest(nonce: &[u8], expiry: &[u8], secret: &[u8]) -> Vec<u8> {
-    let mut digest = HmacSha256::new_varkey(secret).expect("create HMACSHA256 from varkey");
-    digest.input(nonce);
-    digest.input(expiry);
-    digest.input(secret);
-    let result = digest.result();
-    result.code().into_iter().collect()
+pub(crate) fn compute_signature(nonce: &[u8], expiry: &[u8], secret: &[u8]) -> Vec<u8> {
+    let mut sign = HmacSha256::new_varkey(secret).expect("create HMACSHA256 from varkey");
+    sign.input(nonce);
+    sign.input(expiry);
+    let result = sign.result();
+    result.code().to_vec()
 }


### PR DESCRIPTION
- rust-crypto の作者がすでにやる気を失っているっぽいので rust-crypto を使わないようにする。
- HMAC するつもりが単に SHA256 してたので HMAC するように修正
- HMACSHA256 には hmac / sha2 があるのでそれを使う
  - hmac の API ではメッセージ署名を行うと署名機を consume するので digest を保持、再利用できない。このため digest をパラメータ渡ししないようにした。
