### PR TITLE
Add Travis CI and Bors configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: rust
+cache: cargo
+branches:
+  only:
+    - staging
+    - trying

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,2 @@
+status = ["continuous-integration/travis-ci/push"]
+delete_merged_branches = true


### PR DESCRIPTION
Travis CIとBorsが有効になります。
TravisによるテストはBorsを介してのみ走ります。ブランチpush時・PR作成時にはテストは走りません。