### PR TITLE
fix for: cannot infer type for type parameter Tz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,19 @@ authors = ["Yusuke Yoshimoto <y.yoshimoto@f-s-r.jp>"]
 publish = false
 
 [dependencies]
-chrono = "0.4.6"
-rand = "0.5.5"
-byteorder = "1.2.6"
-failure = "0.1.3"
-hmac = "0.7.0"
-sha2 = "0.8.0"
+chrono = "0.4.11"
+rand = "0.7.3"
+byteorder = "1.3.4"
+failure = "0.1.7"
+hmac = "0.7.1"
+sha2 = "0.8.1"
 
 [dev-dependencies]
-base64 = "0.10.0"
-lazy_static = "1.2.0"
-hex = "0.3.2"
-actix-web = "0.7.14"
-mime = "0.3.12"
-serde_derive = "1.0.80"
-serde = "1.0.80"
-futures = "0.1.25"
+base64 = "0.12.0"
+lazy_static = "1.4.0"
+hex = "0.4.2"
+actix-web = "2.0.0"
+mime = "0.3.16"
+serde_derive = "1.0.106"
+serde = "1.0.106"
+futures = "0.3.4"

--- a/src/expiry.rs
+++ b/src/expiry.rs
@@ -55,9 +55,9 @@ pub(crate) trait WriteExpiry: io::Write {
     ///
     /// Otherwise, when the underlying writer fails, this method returns the error.
     fn write_expiry(&mut self, expiry: DateTime<Utc>) -> io::Result<()> {
-        let min = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+        let min = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
         // If the expiry exceeds this instant, the timestamp overflows.
-        let max = DateTime::from_utc(
+        let max = DateTime::<Utc>::from_utc(
             NaiveDateTime::from_timestamp(
                 i64::max_value() / NANOS_IN_SEC,
                 (i64::max_value() % NANOS_IN_SEC) as u32,


### PR DESCRIPTION
this is a fix for current versions of the dependencies, for the error:

`   Compiling csrf-token v0.2.2 (/g/rich/w/timescope/csrf-token/a/csrf-token)
error[E0283]: type annotations needed for `chrono::DateTime<Tz>`
  --> src/expiry.rs:58:19
   |
58 |         let min = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
   |             ---   ^^^^^^^^^^^^^^^^^^ `
   |             |
   |             consider giving `min` the explicit type `chrono::DateTime<Tz>`, where the type parameter `Tz` is specified
   |
   = note: cannot resolve `_: chrono::TimeZone`
   = note: required by `chrono::DateTime::<Tz>::from_utc`
`