### PR TITLE
migrate to https for read-only access

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generation and verification of CSRF prevention tokens.
 Add the following dependency to `Cargo.toml`.
 
 ```
-csrf-token = { git = "ssh://git@github.com/future-science-research/csrf-token.git", branch="v0.2.x" }
+csrf-token = { git = "https://github.com/future-science-research/csrf-token.git", branch="v0.2.x" }
 ```
 
 ## Running Example


### PR DESCRIPTION
    Updating git repository `ssh://git@github.com/future-science-research/csrf-token.git`
error: failed to get `csrf-token` as a dependency of package `csrf-token-demo v0.1.0 (csrf-token-demo)`

Caused by:
  failed to load source for dependency `csrf-token`

Caused by:
  Unable to update ssh://git@github.com/future-science-research/csrf-token.git?branch=v0.2.x

Caused by:
  failed to clone into: ~/.cargo/git/db/csrf-token-dd5e2614fbea3ea8

Caused by:
  failed to authenticate when downloading repository

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  no authentication available