### PR TITLE
 type annotations needed

### DIFF
--- a/src/expiry.rs
+++ b/src/expiry.rs
@@ -55,9 +55,9 @@ pub(crate) trait WriteExpiry: io::Write {
     ///
     /// Otherwise, when the underlying writer fails, this method returns the error.
     fn write_expiry(&mut self, expiry: DateTime<Utc>) -> io::Result<()> {
-        let min = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+        let min: chrono::DateTime<Utc> = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
         // If the expiry exceeds this instant, the timestamp overflows.
-        let max = DateTime::from_utc(
+        let max: chrono::DateTime<Utc> = DateTime::from_utc(
             NaiveDateTime::from_timestamp(
                 i64::max_value() / NANOS_IN_SEC,
                 (i64::max_value() % NANOS_IN_SEC) as u32,
@@ -71,7 +71,7 @@ pub(crate) trait WriteExpiry: io::Write {
         self.write_i64::<BigEndian>(expiry.timestamp_nanos())
     }
 }
-
+time
 impl<T: io::Write> WriteExpiry for T {}
 
 pub(crate) fn bytes_to_expiry(bytes: &[u8]) -> DateTime<Utc> {


### PR DESCRIPTION
error[E0283]: type annotations needed for `chrono::DateTime<Tz>`
  --> ~/.cargo/git/checkouts/csrf-token-27be32f3858c70a3/9096e86/src/expiry.rs:58:19
   |
58 |         let min = DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
   |             ---   ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Tz`
   |             |
   |             consider giving `min` the explicit type `chrono::DateTime<Tz>`, where the type parameter `Tz` is specified
   |
   = note: cannot satisfy `_: chrono::TimeZone`
   = note: required by `chrono::DateTime::<Tz>::from_utc`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0283`.
error: could not compile `csrf-token`